### PR TITLE
mkdir Moneydance support dir

### DIFF
--- a/launch-moneydance.sh
+++ b/launch-moneydance.sh
@@ -83,6 +83,7 @@ use_sandbox="-DSandboxEnabled=true"
 # NOTE: I set '-Dinstall4j.exeDir=x' to help my Toolbox extension - this is not needed
 
 # Redirect output to the Moneydance console window...
+mkdir -v -p "${my_user_path}/Library/Containers/com.infinitekind.MoneydanceOSX/Data/Library/Application Support/Moneydance"
 console_file="${my_user_path}/Library/Containers/com.infinitekind.MoneydanceOSX/Data/Library/Application Support/Moneydance/errlog.txt"
 ${java} --version
 


### PR DESCRIPTION
If the support dir is not present on first using this script, then the launch fails because there is no home for errlog.txt and you have to mkdir it manually before a successful launch.