### PR TITLE
Loosen number-of-decimal-places limit

### DIFF
--- a/source/toolbox/toolbox.py
+++ b/source/toolbox/toolbox.py
@@ -19079,7 +19079,7 @@ now after saving the file, restart Moneydance
                     myPopupInformationBox(toolbox_frame_, txt,theMessageType=JOptionPane.WARNING_MESSAGE)
                     return
 
-                if int(newDecimal) >= 0 and int(newDecimal) <= 8:
+                if int(newDecimal) >= 0 and int(newDecimal) <= 16:
                     newDecimal = int(newDecimal)
                     break
 


### PR DESCRIPTION
I was trying to change the decimal-places setting for a security to match that used in the bank's transaction history, but the bank involved tracks mutual fund transactions to >8 places and Toolbox wouldn't accept that. I am not sure if there's an underlying reason for the current limit of 8, but I can *create* a security with >8 places, so I assume that is technically allowed and the sanity check here is just over-aggressive. This PR doubles the limit to 16.

(I tried to edit the limit locally, but MD silently refused to open the toolbox afterward. I'm guessing it has some checksum or signature check for extensions.)